### PR TITLE
chore: add 5-day minimum release age to Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,10 @@
 
   "labels": ["dependencies"],
 
+  // Wait 5 days after a new release before creating a PR — avoids yanked or
+  // broken releases that are quickly patched by upstream maintainers.
+  "minimumReleaseAge": "5 days",
+
   // GitHub Actions: always pin to digest (full commit SHA) so tags cannot be
   // silently mutated by a compromised upstream maintainer.
   "github-actions": {


### PR DESCRIPTION
## Summary

- `minimumReleaseAge: "5 days"` をトップレベルに追加
- 新バージョンリリースから5日間はPRが作成されなくなる
- リリース直後に発覚するバグや yanked パッケージを踏むリスクを低減

## Test plan

- [x] Renovate の設定バリデーションが通ること（`renovate-config-validator` or Renovate Dashboard で確認）
- [ ] 次回 Renovate 実行時に、リリースから5日未満のパッケージのPRが作成されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)