### PR TITLE
chore: update devcontainer node digest and fix textlint extension ID

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # Pinned to a specific digest so Renovate can track and update it automatically.
 # The digest ensures reproducible builds even if the tag is re-pushed upstream.
-FROM node:lts-alpine3.22@sha256:f587a14b20e59fa6706b0bd82ef3ee330fd4c49f6372e37ed4920d0b6874e4ec
+FROM node:lts-alpine3.22@sha256:191c9f0080fcbbc6547a85dc0ff7988072214a355aabdc1d2ec55a7dae5eea8a
 
 RUN apk update && \
     apk --no-cache add git openssh && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,15 +22,13 @@
         "oderwat.indent-rainbow",
         "esbenp.prettier-vscode",
         "mhutchie.git-graph",
-        "taichi.vscode-textlint",
+        "3w36zj6.textlint",
         "negokaz.zenn-editor"
       ]
     }
   },
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  "forwardPorts": [
-    8000
-  ],
+  "forwardPorts": [8000],
   "remoteEnv": {
     "CHOKIDAR_USEPOLLING": "true"
   },


### PR DESCRIPTION
## Summary

- Bump `node:lts-alpine3.22` image digest to latest for reproducible builds
- Replace deprecated `taichi.vscode-textlint` VS Code extension with `3w36zj6.textlint`
- Minor style: compact `forwardPorts` to single-line

## Test plan

- [x] Open repo in Dev Container and verify it builds successfully
- [x] Confirm textlint extension installs correctly in VS Code